### PR TITLE
Update max line length for black and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,13 @@ repos:
   rev: 5.13.2
   hooks:
   - id: isort
-    args: ["--profile", "black", "--filter-files", "--line-length=72"]
+    args: ["--profile", "black", "--filter-files", "--line-length=120"]
 
 - repo: https://github.com/psf/black
   rev: 24.1.1
   hooks:
   - id: black
-    args: ["--line-length=72"]
+    args: ["--line-length=120"]
     #language_version: python3.11
 
 - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
Changelogs:

- Make the max line length consistent with flake8 i.e. 120.