### PR TITLE
Run mypy checks on repo with mypy config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
 
           run_mypy = False
 
-          if os.path.isfile('mypy.ini') or os.path.isfile('.mypy.in'):
+          if os.path.isfile('mypy.ini') or os.path.isfile('.mypy.ini'):
             run_mypy = True
 
           try:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: ['--maxkb=51200']
@@ -13,11 +13,27 @@ repos:
       - id: debug-statements
       - id: requirements-txt-fixer
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+  - repo: local
     hooks:
       - id: mypy
-        stages: [manual]
+        name: mypy
+        description: "Run mypy if mypy.ini exists"
+        entry: |
+          python -c "
+          import os, subprocess, sys;
+
+          if os.path.isfile('mypy.ini'):
+            result = subprocess.run(['mypy'] + sys.argv[1:])
+            sys.exit(1 if result.returncode else 0)
+          else:
+            sys.exit(0)
+          "
+        language: python
+        'types_or': [python, pyi]
+        args: ["--ignore-missing-imports", "--scripts-are-modules", "--follow-imports=skip"]
+        require_serial: true
+        additional_dependencies: ["mypy"]
+        minimum_pre_commit_version: '2.9.2'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,16 +17,26 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        description: "Run mypy if mypy.ini exists"
+        description: "Run mypy if mypy configuration exists"
         entry: |
           python -c "
-          import os, subprocess, sys;
+          import os, subprocess, sys, tomllib
 
-          if os.path.isfile('mypy.ini'):
+          run_mypy = False
+
+          if os.path.isfile('mypy.ini') or os.path.isfile('.mypy.in'):
+            run_mypy = True
+
+          try:
+            with open('pyproject.toml', 'rb') as file:
+                pyproject = tomllib.load(file)
+                run_mypy = 'tool' in pyproject and 'mypy' in pyproject['tool']
+          except (FileNotFoundError, tomllib.TOMLDecodeError):
+            pass
+
+          if run_mypy:
             result = subprocess.run(['mypy'] + sys.argv[1:])
             sys.exit(1 if result.returncode else 0)
-          else:
-            sys.exit(0)
           "
         language: python
         'types_or': [python, pyi]


### PR DESCRIPTION
Pre-commit will run mypy for repo's having mypy [configuration](https://mypy.readthedocs.io/en/stable/config_file.html) file.

1. `mypy.ini`
2. `.mypy.ini`
3. `pyproject.toml` (containing a `[tool.mypy]` section)

Note: `setup.cfg` is not supported